### PR TITLE
DEVOPS-473: Add moved-to-monorepo notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> ⚠️ **Moved to the monorepo.**
+> This module now lives in [`opstimus/terraform-modules`](https://github.com/opstimus/terraform-modules) at `modules/aws-vpc`.
+>
+> ```hcl
+> source = "git::https://github.com/opstimus/terraform-modules.git//modules/aws-vpc?ref=aws-vpc/v2.2.2"
+> ```
+>
+> This repository remains for existing consumers; new development happens in the monorepo.
+
 # VPC Module
 
 ## Description


### PR DESCRIPTION
This module has been migrated to [opstimus/terraform-modules](https://github.com/opstimus/terraform-modules) (`modules/aws-vpc`). This PR prepends a notice to the README pointing existing consumers to the new source location. This repo remains live; no other changes.